### PR TITLE
Migrate to April 12, 2016 snapshot

### DIFF
--- a/Sources/BytesSequence.swift
+++ b/Sources/BytesSequence.swift
@@ -10,7 +10,7 @@ import Foundation
 import C7
 
 //TODO: func anyGenerator is renamed to AnyGenerator in Swift 2.2, until then it's just dirty hack for linux (because swift >= 2.2 is available for Linux)
-public func CS_AnyGenerator<Element>(body: () -> Element?) -> AnyIterator<Element> {
+public func CS_AnyGenerator<Element>(_ body: () -> Element?) -> AnyIterator<Element> {
     return AnyIterator(body: body)
 }
 

--- a/Sources/CSArrayType+Extension.swift
+++ b/Sources/CSArrayType+Extension.swift
@@ -43,7 +43,7 @@ public extension CSArrayType where Iterator.Element == Byte {
     public init(base64: String) {
         self.init()
         
-        guard let decodedData = NSData(base64EncodedString: base64, options: []) else {
+        guard let decodedData = NSData(base64Encoded: base64, options: []) else {
             return
         }
         

--- a/Sources/Generics.swift
+++ b/Sources/Generics.swift
@@ -23,7 +23,7 @@ extension UInt64:Initiable {}
 
 /// Initialize integer from array of bytes.
 /// This method may be slow
-public func integerWithBytes<T: Integer where T:ByteConvertible, T: BitshiftOperationsType>(bytes: [Byte]) -> T {
+public func integerWithBytes<T: Integer where T:ByteConvertible, T: BitshiftOperationsType>(_ bytes: [Byte]) -> T {
     var bytes = bytes.reversed() as Array<Byte> //FIXME: check it this is equivalent of Array(...)
     if bytes.count < sizeof(T) {
         let paddingCount = sizeof(T) - bytes.count
@@ -45,7 +45,7 @@ public func integerWithBytes<T: Integer where T:ByteConvertible, T: BitshiftOper
 
 /// Array of bytes, little-endian representation. Don't use if not necessary.
 /// I found this method slow
-public func arrayOfBytes<T>(value:T, length:Int? = nil) -> [Byte] {
+public func arrayOfBytes<T>(_ value:T, length:Int? = nil) -> [Byte] {
     let totalBytes = length ?? sizeof(T)
     
     let valuePointer = UnsafeMutablePointer<T>.init(allocatingCapacity: 1)
@@ -80,7 +80,7 @@ public func << <T:UnsignedInteger>(lhs: T, rhs: Int) -> UInt {
 
 // Generic function itself
 // FIXME: this generic function is not as generic as I would. It crashes for smaller types
-public func shiftLeft<T: SignedInteger where T: Initiable>(value: T, count: Int) -> T {
+public func shiftLeft<T: SignedInteger where T: Initiable>(_ value: T, count: Int) -> T {
     if (value == 0) {
         return 0;
     }
@@ -104,38 +104,38 @@ public func shiftLeft<T: SignedInteger where T: Initiable>(value: T, count: Int)
 }
 
 // for any f*** other Integer type - this part is so non-Generic
-public func shiftLeft(value: UInt, count: Int) -> UInt {
+public func shiftLeft(_ value: UInt, count: Int) -> UInt {
     return UInt(shiftLeft(Int(value), count: count)) //FIXME: count:
 }
 
-public func shiftLeft(value: Byte, count: Int) -> Byte {
+public func shiftLeft(_ value: Byte, count: Int) -> Byte {
     return Byte(shiftLeft(UInt(value), count: count))
 }
 
-public func shiftLeft(value: UInt16, count: Int) -> UInt16 {
+public func shiftLeft(_ value: UInt16, count: Int) -> UInt16 {
     return UInt16(shiftLeft(UInt(value), count: count))
 }
 
-public func shiftLeft(value: UInt32, count: Int) -> UInt32 {
+public func shiftLeft(_ value: UInt32, count: Int) -> UInt32 {
     return UInt32(shiftLeft(UInt(value), count: count))
 }
 
-public func shiftLeft(value: UInt64, count: Int) -> UInt64 {
+public func shiftLeft(_ value: UInt64, count: Int) -> UInt64 {
     return UInt64(shiftLeft(UInt(value), count: count))
 }
 
-public func shiftLeft(value: Int8, count: Int) -> Int8 {
+public func shiftLeft(_ value: Int8, count: Int) -> Int8 {
     return Int8(shiftLeft(Int(value), count: count))
 }
 
-public func shiftLeft(value: Int16, count: Int) -> Int16 {
+public func shiftLeft(_ value: Int16, count: Int) -> Int16 {
     return Int16(shiftLeft(Int(value), count: count))
 }
 
-public func shiftLeft(value: Int32, count: Int) -> Int32 {
+public func shiftLeft(_ value: Int32, count: Int) -> Int32 {
     return Int32(shiftLeft(Int(value), count: count))
 }
 
-public func shiftLeft(value: Int64, count: Int) -> Int64 {
+public func shiftLeft(_ value: Int64, count: Int) -> Int64 {
     return Int64(shiftLeft(Int(value), count: count))
 }

--- a/Sources/HashProtocol.swift
+++ b/Sources/HashProtocol.swift
@@ -11,5 +11,5 @@
 public protocol HashProtocol {
     static var size: Int { get }
     
-    static func calculate(message: Array<UInt8>) -> [Byte]
+    static func calculate(_ message: Array<UInt8>) -> [Byte]
 }

--- a/Sources/IntExtension.swift
+++ b/Sources/IntExtension.swift
@@ -25,16 +25,16 @@ import C7
 /* array of bytes */
 extension Int {
     /** Array of bytes with optional padding (little-endian) */
-    public func bytes(totalBytes: Int = sizeof(Int)) -> [Byte] {
+    public func bytes(_ totalBytes: Int = sizeof(Int)) -> [Byte] {
         return arrayOfBytes(self, length: totalBytes)
     }
     
-    public static func withBytes(bytes: ArraySlice<Byte>) -> Int {
+    public static func withBytes(_ bytes: ArraySlice<Byte>) -> Int {
         return Int.withBytes(Array(bytes))
     }
     
     /** Int with array bytes (little-endian) */
-    public static func withBytes(bytes: [Byte]) -> Int {
+    public static func withBytes(_ bytes: [Byte]) -> Int {
         return integerWithBytes(bytes)
     }
 }
@@ -45,13 +45,13 @@ extension Int {
 extension Int {
     
     /** Shift bits to the left. All bits are shifted (including sign bit) */
-    private mutating func shiftLeft(count: Int) -> Int {
+    private mutating func shiftLeft(_ count: Int) -> Int {
         self = CryptoEssentials.shiftLeft(self, count: count) //FIXME: count:
         return self
     }
     
     /** Shift bits to the right. All bits are shifted (including sign bit) */
-    private mutating func shiftRight(count: Int) -> Int {
+    private mutating func shiftRight(_ count: Int) -> Int {
         if (self == 0) {
             return self;
         }

--- a/Sources/NSData+Extensions.swift
+++ b/Sources/NSData+Extensions.swift
@@ -11,8 +11,8 @@ import C7
 
 extension NSMutableData {
     /** Convenient way to append bytes */
-    public func appendBytes(arrayOfBytes: [Byte]) {
-        self.appendBytes(arrayOfBytes, length: arrayOfBytes.count)
+    public func appendBytes(_ arrayOfBytes: [Byte]) {
+        self.append(arrayOfBytes, length: arrayOfBytes.count)
     }
 }
 
@@ -45,7 +45,7 @@ extension NSData {
         self.init(data: NSData.withBytes(bytes))
     }
     
-    class public func withBytes(bytes: [Byte]) -> NSData {
+    class public func withBytes(_ bytes: [Byte]) -> NSData {
         return NSData(bytes: bytes, length: bytes.count)
     }
 }

--- a/Sources/Utils.swift
+++ b/Sources/Utils.swift
@@ -8,39 +8,39 @@
 
 import C7
 
-public func rotateLeft(v:Byte, _ n:Byte) -> Byte {
+public func rotateLeft(_ v:Byte, _ n:Byte) -> Byte {
     return ((v << n) & 0xFF) | (v >> (8 - n))
 }
 
-public func rotateLeft(v:UInt16, _ n:UInt16) -> UInt16 {
+public func rotateLeft(_ v:UInt16, _ n:UInt16) -> UInt16 {
     return ((v << n) & 0xFFFF) | (v >> (16 - n))
 }
 
-public func rotateLeft(v:UInt32, _ n:UInt32) -> UInt32 {
+public func rotateLeft(_ v:UInt32, _ n:UInt32) -> UInt32 {
     return ((v << n) & 0xFFFFFFFF) | (v >> (32 - n))
 }
 
-public func rotateLeft(x:UInt64, _ n:UInt64) -> UInt64 {
+public func rotateLeft(_ x:UInt64, _ n:UInt64) -> UInt64 {
     return (x << n) | (x >> (64 - n))
 }
 
-public func rotateRight(x:UInt16, n:UInt16) -> UInt16 {
+public func rotateRight(_ x:UInt16, n:UInt16) -> UInt16 {
     return (x >> n) | (x << (16 - n))
 }
 
-public func rotateRight(x:UInt32, n:UInt32) -> UInt32 {
+public func rotateRight(_ x:UInt32, n:UInt32) -> UInt32 {
     return (x >> n) | (x << (32 - n))
 }
 
-public func rotateRight(x:UInt64, n:UInt64) -> UInt64 {
+public func rotateRight(_ x:UInt64, n:UInt64) -> UInt64 {
     return ((x >> n) | (x << (64 - n)))
 }
 
-public func reverseBytes(value: UInt32) -> UInt32 {
+public func reverseBytes(_ value: UInt32) -> UInt32 {
     return ((value & 0x000000FF) << 24) | ((value & 0x0000FF00) << 8) | ((value & 0x00FF0000) >> 8)  | ((value & 0xFF000000) >> 24);
 }
 
-public func toUInt32Array(slice: ArraySlice<Byte>) -> Array<UInt32> {
+public func toUInt32Array(_ slice: ArraySlice<Byte>) -> Array<UInt32> {
     var result = Array<UInt32>()
     result.reserveCapacity(16)
     
@@ -55,7 +55,7 @@ public func toUInt32Array(slice: ArraySlice<Byte>) -> Array<UInt32> {
     return result
 }
 
-public func toUInt64Array(slice: ArraySlice<UInt8>) -> Array<UInt64> {
+public func toUInt64Array(_ slice: ArraySlice<UInt8>) -> Array<UInt64> {
     var result = Array<UInt64>()
     result.reserveCapacity(32)
     for idx in stride(from: slice.startIndex, to: slice.endIndex, by: sizeof(UInt64)) {
@@ -73,7 +73,7 @@ public func toUInt64Array(slice: ArraySlice<UInt8>) -> Array<UInt64> {
     return result
 }
 
-public func xor(a: [Byte], _ b:[Byte]) -> [Byte] {
+public func xor(_ a: [Byte], _ b:[Byte]) -> [Byte] {
     var xored = [Byte](repeating: 0, count: min(a.count, b.count))
     for i in 0..<xored.count {
         xored[i] = a[i] ^ b[i]


### PR DESCRIPTION
I've updated this to the new snapshot, keeping the API for code the same. The main changes include adding the implicit `_` in function declarations that changed in Swift 4/12, as well as changes to the Foundation / Swift stdlib apis.

We need to change `Package.swift` to the new tag of C7 that's also Swift 4/12 compatible, presumably `0.5.0`, but I've left that out of this PR for now. 

https://github.com/open-swift/C7/pull/17